### PR TITLE
Refactor fetch to fetch all, fetch whats needed until that comes in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import Navbar from './Components/Navbar'
 import ProductContainer from './Components/ProductContainer'
 import { Component, useEffect } from 'react'
-import CategoryContainer from './Components/Category/Category'
+import CategoryContainer from './Components/CategoryContainer'
 import {BrowserRouter as Router} from 'react-router-dom'
 import {fetchAllProducts, fetchByProductTag, fetchByProductType } from '/Users/mayakappen/turing/3module/happy-skin/src/apiCalls'
 
@@ -14,41 +14,57 @@ class App extends Component {
     this.state = {
       products: [],
       filtered: [],
+      temp: [],
       category: '',
+      currentTag: '',
       tags: []
 }
 }
 
 handleTag = event => {
-  fetchByProductTag(event.target.id)
-  .then(data => this.setState({filtered: data, tags: !this.state.tags.includes(event.target.id) && this.state.tags.push('/' + event.target.id)}))
-  .catch(err => console.log(err))
-  // if (this.state.filtered === []) {
-  //   let filteredProducts = this.state.products
-  //   filteredProducts.filter(product => product['tag_list'].includes(event.target.id))
-  // this.setState({tag: event.target.id, filtered: filteredProducts })
-  // }
-  // else {
-  //   let filteredProducts = this.state.filtered.map(product => product.tag_list.filter(tag => tag === event.target.id))
-  //   this.setState({tag: event.target.id, filtered: filteredProducts })
-  // }
+  let filtered = []
+  if (this.state.products.length === 0) {
+   fetchByProductTag(event.target.id)
+    .then(data => this.setState({filtered: data, tags: [...this.state.tags, event.target.id], currentTag: '/' + event.target.id}))
+    .catch(err => console.log(err))
+  } 
+  else {
+      this.state.products.forEach(product => {
+       if (product.tag_list.includes(event.target.id)) {
+       filtered.push(product)
+       }
+    })
+    this.setState({filtered: filtered, currentTag: '/' + event.target.id, tags: [...this.state.tags, event.target.id] })}
 }
 
+
+componentDidMount() {
+  fetchAllProducts()
+    .then(data => this.setState({products: data}))
+    .catch(error => console.log(error))
+  }
+
 handleType = event => {
+  this.setState({category: `/${event.target.id}`})
+  if  (this.state.products.length === 0) {
+    fetchByProductType(event.target.id)
+    .then(data => this.setState({
+    filtered: data
+    }))
+    .catch(error => console.log(error))
+  }
+  else {
   let match = this.state.products.find(product => product.product_type === event.target.id)
   if (match !== undefined) {
     let filtered = this.state.products.filter(product => product.product_type === event.target.id)
     this.setState({filtered: filtered, category: `/${event.target.id}`})
   } 
-  else {
-    fetchByProductType(event.target.id)
-      .then(data => this.setState({ products: this.state.products.concat(data), category: `/${event.target.id}` }))
-  }
+}
 }
 render() {
   return (
     <Router>
-      <Navbar typeHandler={this.handleType} tagHandler={this.handleTag} category={this.state.category} handlePath={this.handlePath} tags={this.state.tags}/>
+      <Navbar typeHandler={this.handleType} tagHandler={this.handleTag} category={this.state.category} handlePath={this.handlePath} tag={this.state.currentTag}/>
      <ProductContainer props={this.state.category} />
       <CategoryContainer />
     </Router>

--- a/src/Components/Category/Category.js
+++ b/src/Components/Category/Category.js
@@ -8,3 +8,5 @@ const Category = () => {
         </>
     )
 }
+
+export default Category;

--- a/src/Components/CategoryContainer.js
+++ b/src/Components/CategoryContainer.js
@@ -1,7 +1,7 @@
-import Category from './Category'
+import Category from './Category/Category'
 import React from 'react'
 
-const CategoryContainer = (props) => {
+const CategoryContainer = () => {
     return (
     <div className="category-container">
       <Category className ="Hypoallergenic" id="Hypoallergenic"/>

--- a/src/Components/Navbar/index.js
+++ b/src/Components/Navbar/index.js
@@ -22,34 +22,34 @@ render() {
             </NavLink>
             <Bars />
                 <NavMenu onClick={this.props.typeHandler}>
-                <NavLink to="/foundation" id="foundation" >
+                <NavLink to={"/foundation" + this.props.tag} id="foundation" >
                     Foundation
                 </NavLink>
-                <NavLink to="/blush" id="blush">
+                <NavLink to={"/blush" + this.props.tag} id="blush">
                     Blush
                 </NavLink>
-                 <NavLink to="/bronzer" id="bronzer">
+                 <NavLink to={"/bronzer" + this.props.tag} id="bronzer">
                     Bronzer
                  </NavLink>
-                <NavLink to="/eyebrow" id="eyebrow">
+                <NavLink to={"/eyebrow" + this.props.tag} id="eyebrow">
                     Eyebrows
                 </NavLink>j
-                <NavLink to="/eyeliner" id="eyeliner">
+                <NavLink to={"/eyeliner" + this.props.tag} id="eyeliner">
                     Eyeliner
                 </NavLink>
-                <NavLink to="/eyeshadow" id="eyeshadow">
+                <NavLink to={"/eyeshadow" + this.props.tag} id="eyeshadow">
                     Eyeshadow
                 </NavLink>
-                <NavLink to="/lip-liner" id="lip-liner">
+                <NavLink to={"/lip-liner" + this.props.tag} id="lip-liner">
                     Lip Liner
                 </NavLink>
-                <NavLink to="/lipstick" id="lipstick">
+                <NavLink to={"/lipstick" + this.props.tag} id="lipstick">
                     Lipstick
                 </NavLink>
-                <NavLink to="/mascara" id="mascara">
+                <NavLink to={"/mascara" + this.props.tag} id="mascara">
                     Mascara
                 </NavLink>
-                <NavLink to="/nail-polish" id="nail-polish">
+                <NavLink to={"/nail-polish" + this.props.tag} id="nail-polish">
                     Nail Polish
                 </NavLink>
             </NavMenu>
@@ -59,58 +59,58 @@ render() {
         </Nav>
         <Tags>
             <NavTags onClick={this.props.tagHandler}>
-                <NavLink to={this.props.tags + this.props.category}id="hypoallergenic">
+                    <NavLink to={this.props.category + '/hypoallergenic'} id="hypoallergenic">
                     HypoAllergenic
                 </NavLink>
-                    <NavLink to={this.props.tags + this.props.category} id="vegan">
+                <NavLink to={this.props.category + '/vegan'} id="vegan">
                     Vegan
                 </NavLink>
-                    <NavLink to={'/cruelty-free' + this.props.category} id="cruelty+free">
+                <NavLink to={this.props.category + '/cruelty-free'} id="cruelty+free">
                     Cruelty-Free
                 </NavLink>
-                <NavLink to="/natural" id="natural">
+                <NavLink to={this.props.category + '/natural'} id="natural">
                     Natural
                 </NavLink>
-                <NavLink to="/organic" id="organic">
+                <NavLink to={this.props.category + '/organic'} id="organic">
                     Organic
                 </NavLink>
-                <NavLink to="/ewg-verified" id="ewg+verified">
+                <NavLink to={this.props.category + '/ewg-verified'} id="ewg+verified">
                     EWG-Verified
                 </NavLink>
-                <NavLink to="/purpicks" id="purpicks">
-                    Purpicks
+                <NavLink to={this.props.category + '/purpicks'} id="purpicks">
+                Purpicks
                 </NavLink>
-                <NavLink to="/eco-cert" id="eco+cert">
+                <NavLink to={this.props.category + '/eco-cert'} id="eco+cert">
                     EcoCert
                 </NavLink>
-                <NavLink to="/no-talc" id="No+Talc">
+                <NavLink to={this.props.category + '/no-talc'} id="No+Talc">
                     No-Talc
                 </NavLink>
-                <NavLink to="/chemical-free" id="chemical+free">
+                <NavLink to={this.props.category + '/chemical-free'} id="chemical+free">
                     Chemical-Free
                 </NavLink>
-                <NavLink to="/alcohol-free" id="alcohol+free">
+                <NavLink to={this.props.category + '/alcohol-free'} id="alcohol+free">
                     Alcohol-Free
                 </NavLink>
-                <NavLink to="/silicone-free" id="silicone+free">
+                <NavLink to={this.props.category + '/silicone-free'} id="silicone+free">
                     Silicone-Free
                 </NavLink>
-                <NavLink to="/oil-free" id="oil+free">
+                <NavLink to={this.props.category + '/oil-free'} id="oil+free">
                     Oil-Free
                 </NavLink>
-                <NavLink to="/dairy-free" id="dairy+free">
+                    <NavLink to={this.props.category + '/dairy-free'} id="dairy+free">
                     Dairy-Free
                 </NavLink>
-                <NavLink to="/peanut-free" id="peanut+free">
+                    <NavLink to={this.props.category + '/peanut-free'} id="peanut+free">
                     Peanut-Free
                 </NavLink>
-                <NavLink to="/gluten-free" id="gluten+free">
+                    <NavLink to={this.props.category + '/gluten-free'} id="gluten+free">
                     Gluten-Free
                 </NavLink>
-                <NavLink to="/sugar-free" id="sugar+free">
+                    <NavLink to={this.props.category + '/sugar-free'} id="sugar+free">
                     Sugar-Free
                 </NavLink>
-                <NavLink to="/water-free" id="water+free">
+                <NavLink to={this.props.category + '/water-free'} id="water+free">
                     Water-Free
                 </NavLink>
 

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,6 +1,6 @@
 import React from 'react'
 export const fetchAllProducts = () => {
-    return fetch(`http://makeup-api.herokuapp.com/api/v1/products.json`)
+    return fetch('https://makeup-api.herokuapp.com/api/v1/products.json')
     .then(res=> res.json())
 }
 export const fetchByProductType = (type ) => {


### PR DESCRIPTION
-refactor fetch to do a fetch all upon app mount
-if a user clicks a category before all products are fetched, it fetches the needed info from the required endpoint only. 
-if the all products fetch is completed, all further filtering happens within app state, this seemed like a good solution to either having too much network traffic or too much page load time
-added a function to clear all current filters
-passed the function into a button in the navbar that also routes the user back home
*fixed bug with dynamic routing
*removed redundant files in package.json
*fixed import/export of category and category container